### PR TITLE
Update BlockFetcher.cs

### DIFF
--- a/NBitcoin.Indexer/BlockFetcher.cs
+++ b/NBitcoin.Indexer/BlockFetcher.cs
@@ -149,7 +149,7 @@ namespace NBitcoin.Indexer
 
             if (NeedSave)
             {
-                _LastSaved = DateTime.Now;
+                _LastSaved = DateTime.UtcNow;
             }
         }
 


### PR DESCRIPTION
_LastSaved should be updated with  DateTime.UtcNow and not DateTime.Now to be consistent with the rest of the checkpoint save functions 